### PR TITLE
Add support for virtualenvwrapper in Harvest init

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ This version of Harvest requires Python 2.6 or 2.7.
 ```bash
 $ harvest init [--verbose] [--no-env] [--no-input] project_name
 ```
+This command performs the following steps:
+
+- Create a new virtualenv environment (name `project_name`-env)
+- Installs Django
+- Creates a starter project using the built-in Harvest template
+- Installs the base dependencies
+- Syncs and migrates a SQLite database, this requires you to answer a couple
+prompts (unless `--no-input` is passed)
+- Collects the static CSS and JavaScript files (mainly due to Cilantro)
+- Prints out a message to perform a couple commands in your shell
 
 **Arguments**
 
@@ -41,18 +51,6 @@ installed in the correct site-packages directory.
 currently includes the prompt for setting up a superuser during the database
 sync. This is primarily useful for performing scripted builds.
 
-
-This command performs the following steps:
-
-- Create a new virtualenv environment (name `project_name`-env)
-- Installs Django
-- Creates a starter project using the built-in Harvest template
-- Installs the base dependencies
-- Syncs and migrates a SQLite database, this requires you to answer a couple
-prompts (unless `--no-input` is passed)
-- Collects the static CSS and JavaScript files (mainly due to Cilantro)
-- Prints out a message to perform a couple commands in your shell
-
 `--template` - Specify a template to base your Harvest application on. By
 default `harvest init` will base its build off of
 `https://github.com/cbmi/harvest-template`. By passing a URL to this option
@@ -63,6 +61,12 @@ bootstrapping tasks beyond creating the virtualenv and installing of
 dependencies to the `harvest_bootstrap` task. This could be useful in situations
 where further assumptions can be made about a new Harvest deployment
 (i.e. containerization, use of a specific DB, specific Django models, etc.).
+
+`--venv-wrap` - If you are using virtualenvwrapper to handle your python virtual
+environments you can set this flag to create a virtualenv in accordance with
+the conventions of that utility -- The name of your environment will correspond
+to your project name and will be created in the directory specified by the
+`WORKON_HOME` environment variable.
 
 **Post-Setup**
 

--- a/harvest/decorators.py
+++ b/harvest/decorators.py
@@ -34,16 +34,18 @@ def cli(*args, **kwargs):
     return decorator
 
 
-def virtualenv(path):
+def virtualenv(path, venv_wrap, project_name):
     "Wraps a function and prefixes the call with the virtualenv active."
     if path is None:
         activate = None
     else:
         activate = os.path.join(path, 'bin/activate')
-
     def decorator(func):
         @wraps(func)
         def inner(*args, **kwargs):
+            if venv_wrap:
+                with prefix('source /usr/local/bin/virtualenvwrapper.sh && workon {0}'.format(project_name)):
+                    return func(*args, **kwargs)
             if path is not None:
                 with prefix('source {0}'.format(activate)):
                     return func(*args, **kwargs)

--- a/harvest/utils.py
+++ b/harvest/utils.py
@@ -5,14 +5,23 @@ from fabric.api import local
 from fabric.colors import red, green
 
 
-def create_virtualenv(env_path):
+def create_virtualenv(env_path, venv_wrap=False, project_name=None):
     if os.path.exists(env_path):
         print(red("Error: Cannot create environment '{0}'. A " \
             "directory with the same already exists.".format(env_path)))
         sys.exit()
     print(green("- Setting up a virtual environment '{0}'".format(env_path)))
-    local('virtualenv {0}'.format(env_path), shell='/bin/bash')
-    os.chdir(env_path)
+    if venv_wrap:
+        try:
+            venv_home = os.environ['WORKON_HOME']
+        except:
+            print(red("It doesn't appear that you have virtualenvwrapper installed correctly"))
+            sys.exit(1)
+        env_path = os.path.join(venv_home, project_name)
+        local('virtualenv {0}'.format(env_path), shell='/bin/bash')
+    else:
+        local('virtualenv {0}'.format(env_path), shell='/bin/bash')
+        os.chdir(env_path)
 
 
 def managepy_chmod():


### PR DESCRIPTION
Since virtualenvwrapper is in widespread use and fits into the development environment of many python users Harvest should have the ability to create a project and setup the virtualenv according to the conventions of virtualenvwrapper. This allows for consistency and convenience in the workflow of the user.
