### PR TITLE
Minor version bump to virtualenv dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 install_requires = [
     'Fabric>=1.8',
-    'virtualenv>=1.10',
+    'virtualenv>=1.11',
 ]
 
 if sys.version_info < (2, 7):


### PR DESCRIPTION
virtualenv 1.10 installs pip 1.4 by default. virtualenv 1.11 installs pip 1.5. 

pip 1.5 has a significant change that requires packages installed from externally hosted sources to be explicitly allowed by passing a --allow-external. 1.4 does not have this requirement. An example of where this might cause an issue is if a template passed to Harvest init has a dependency on the `argparse` package... In virtualenv's created with pip 1.4 installed argparse will install without issue. If the virtualenv has pip 1.5, however, the install will fail. 

This update ensures consistent handling of downstream dependency requirements installed by pip.
