### PR TITLE
Make fabfile command discovery more lenient.

### DIFF
--- a/harvest/commands/init.py
+++ b/harvest/commands/init.py
@@ -163,10 +163,13 @@ def parser(options):
 
     @virtualenv(full_env_path, venv_wrap, project_name)
     def get_available_fabric_cmds():
-        with hide(*hidden_output):
-            avail_cmds = local('fab -l | grep -Eo "\w*$" | xargs', capture=True)
-        avail_cmds = avail_cmds.split(' ')
-        return avail_cmds
+        try:
+            with hide(*hidden_output):
+                avail_cmds = local('fab -l | grep -Eo "\w*$" | xargs', shell='bin/bash', capture=True)
+            avail_cmds = avail_cmds.split(' ')
+            return avail_cmds
+        except:
+            return []
 
     @virtualenv(full_env_path, venv_wrap, project_name)
     def template_bootstrap(allow_input):


### PR DESCRIPTION
In order to support custom templating the Harvest init CLI made an attempt to discover available Fabric commands that might be present in the passed template. On some Ubuntu systems this would fail if shell was not specified as `/bin/bash`. Shell is now explicitly stated in this command, furthermore, if the command still fails it will fallback to generic Harvest application initialization. Fixes #31.
