### PR TITLE
Add support info and project summary to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 [![Build Status](https://travis-ci.org/cbmi/harvest.png?branch=master)](https://travis-ci.org/cbmi/harvest) [![Coverage Status](https://img.shields.io/coveralls/cbmi/harvest.svg)](https://coveralls.io/r/cbmi/harvest?branch=master) [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/cbmi/harvest/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
 
+[Harvest](http://harvest.research.chop.edu) is a [Django](https://www.djangoproject.com/)-based Python and Javascript toolkit for building web applications to integrate, explore, and report on data.  Harvest makes it easy to [bootstrap from your relational tables](http://harvest.research.chop.edu/articles/2013/11/20/using-your-data/) to a Django app with a simple query-builder and reporting interface that automatically uses the relations between your data models.
+
+## Support
+
+If you encounter problems getting started with Harvest, try our [chatroom](http://harvest.research.chop.edu/chat/) or our [Google Group](https://groups.google.com/forum/#!forum/harveststack).
+
 ## Install
 
 ```bash


### PR DESCRIPTION
I mainly wanted to get the contact/support info into the README.  I also injected a variation of Harvest's tagline.  It's a little more concrete than "The Harvest Stack is an open source BSD-licensed toolkit for building web applications for integrating, discovering, and reporting data".

_If_ putting the support info here is a good idea, we probably also want to put it in some other READMEs that first-timers are likely to be working from, e.g. omop_harvest.  Thoughts?

Signed-off-by: Kevin Murphy murphyke@email.chop.edu
