### PR TITLE
Fix update command

### DIFF
--- a/harvest/commands/update.py
+++ b/harvest/commands/update.py
@@ -11,6 +11,6 @@ Updates this Harvest package.
 @cli(description=__doc__)
 def parser(options):
     with hide('running'):
-        bindir = os.path.dirname(local('which harvest', capture=True), shell='/bin/bash')
+        bindir = os.path.dirname(local('which harvest', capture=True, shell='/bin/bash'))
         pip = os.path.join(bindir, 'pip')
         local('{0} install -U harvest'.format(pip), shell='/bin/bash')


### PR DESCRIPTION
Fix typo in update command that was causing an error by passing argument
to wrong function.

Fixes #44

Signed-off-by: Aaron Browne <aaron0browne@gmail.com>