### PR TITLE
Expect full path when template is specified.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ sync. This is primarily useful for performing scripted builds.
 
 `--template` - Specify a template to base your Harvest application on. By
 default `harvest init` will base its build off of
-`https://github.com/cbmi/harvest-template`. By passing a URL to this option
-`harvest init` will attempt to bootstrap the project based on the endpoint
-specified. Additionally, if your provided template contains a Fabric fabfile
-containing a `harvest_bootstrap` task the init command will offload all
+`https://github.com/cbmi/harvest-template/archive/HEAD.zip`. By passing a URL to
+this option `harvest init` will attempt to bootstrap the project based on the
+endpoint specified. Additionally, if your provided template contains a Fabric
+fabfile containing a `harvest_bootstrap` task the init command will offload all
 bootstrapping tasks beyond creating the virtualenv and installing of
 dependencies to the `harvest_bootstrap` task. This could be useful in situations
 where further assumptions can be made about a new Harvest deployment

--- a/harvest/commands/init.py
+++ b/harvest/commands/init.py
@@ -90,7 +90,7 @@ def parser(options):
             sys.exit(1)
 
         if template:
-            archive_url = '{0}/archive/HEAD.zip'.format(template)
+            archive_url = template
             archive = 'custom-template.zip'
         else:
             archive_url = config.TEMPLATE_ARCHIVE_URL.format(harvest_version)


### PR DESCRIPTION
Previously the template option expected the URL of a github repository and would build a URL off of that repository assuming that you would like to use the HEAD of that repository as your template. This commit changes the template option so that it expects the full path to a zipball containing a Harvest template. This allows the user to specify a commit, and also allows for the passing of templates not following Github's repository conventions.

Signed-off-by: Tyler Rivera riverat2@email.chop.edu
